### PR TITLE
Fix routing with HashRouter

### DIFF
--- a/src/utils/App.jsx
+++ b/src/utils/App.jsx
@@ -5,7 +5,8 @@
  */
 
 import React from 'react';
-import { BrowserRouter as Router, Routes, Route } from 'react-router-dom';
+// HashRouter é usado para evitar erros 404 em hospedagens estáticas como a Vercel
+import { HashRouter as Router, Routes, Route } from 'react-router-dom';
 
 // Componentes
 import Navbar from '../components/Navbar';


### PR DESCRIPTION
## Summary
- avoid 404 errors on Vercel by switching to `HashRouter`

## Testing
- `npm test` *(fails: could not find package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68816221fe648328b19811c6bcc2cc0c

## Resumo por Sourcery

Alterar o roteamento de BrowserRouter para HashRouter para evitar erros 404 em hospedagem estática

Correções de Bugs:
- Evitar erros 404 no Vercel usando roteamento baseado em hash

Melhorias:
- Substituir BrowserRouter por HashRouter no componente App

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Switch routing from BrowserRouter to HashRouter to prevent 404 errors on static hosting

Bug Fixes:
- Avoid 404 errors on Vercel by using hash-based routing

Enhancements:
- Replace BrowserRouter with HashRouter in App component

</details>